### PR TITLE
Added value to change the cluster domain in the Certificate

### DIFF
--- a/charts/ndots-admission-controller/templates/cert-manager.yaml
+++ b/charts/ndots-admission-controller/templates/cert-manager.yaml
@@ -21,8 +21,8 @@ spec:
   duration: "{{ .Values.certificate.duration }}"
   commonName: {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc
   dnsNames:
-  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
-  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster-domain }}
+  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster-domain }}
   issuerRef:
     kind: {{ default "Issuer" (.Values.certificate.issuerRef).kind }}
     name: {{ default "ndots-admission-controller" (.Values.certificate.issuerRef).name }}

--- a/charts/ndots-admission-controller/templates/cert-manager.yaml
+++ b/charts/ndots-admission-controller/templates/cert-manager.yaml
@@ -22,7 +22,7 @@ spec:
   commonName: {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc
   dnsNames:
   - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster-domain }}
-  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.cluster-domain }}
+  - {{ include "ndots-admission-controller.fullname" . }}.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: {{ default "Issuer" (.Values.certificate.issuerRef).kind }}
     name: {{ default "ndots-admission-controller" (.Values.certificate.issuerRef).name }}

--- a/charts/ndots-admission-controller/values.yaml
+++ b/charts/ndots-admission-controller/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+cluster-domain: cluster.local
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
By changing the value `cluster-domain` it is now possible to request the certificate for domains other than cluster.local. The default setting will remain cluster.local.